### PR TITLE
Add calculateLeadScore tests

### DIFF
--- a/app/__tests__/contact.test.ts
+++ b/app/__tests__/contact.test.ts
@@ -1,0 +1,43 @@
+import { calculateLeadScore, ContactFormData } from '../contact/page'
+
+describe('calculateLeadScore', () => {
+  it('returns higher score for workflow automation service with urgent need in enterprise company', () => {
+    const data: ContactFormData = {
+      name: 'Jane',
+      email: 'jane@example.com',
+      company: 'Big Corp',
+      serviceType: 'workflow_automation',
+      companySize: 'enterprise',
+      projectUrgency: 'urgent',
+      message: 'Need it fast'
+    }
+    expect(calculateLeadScore(data)).toBe(100)
+  })
+
+  it('computes medium score for medium company planning AI agents project', () => {
+    const data: ContactFormData = {
+      name: 'John',
+      email: 'john@example.com',
+      company: 'Medium Co',
+      serviceType: 'ai_agents',
+      companySize: 'medium',
+      projectUrgency: 'planning',
+      message: 'Looking ahead'
+    }
+    expect(calculateLeadScore(data)).toBe(50 + 25 + 20 + 15)
+  })
+
+  it('uses defaults when values are missing or unknown', () => {
+    const data: ContactFormData = {
+      name: 'Sam',
+      email: 'sam@example.com',
+      company: 'Startup',
+      serviceType: '',
+      companySize: '',
+      projectUrgency: 'exploring',
+      message: 'Tell me more'
+    }
+    const expected = 50 + 10 + 10 + 10
+    expect(calculateLeadScore(data)).toBe(expected)
+  })
+})

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -13,7 +13,7 @@ declare global {
   }
 }
 
-interface ContactFormData {
+export interface ContactFormData {
   name: string
   email: string
   company: string
@@ -95,7 +95,7 @@ export default function Contact() {
   }
 
   // Calculate lead score based on form data
-  const calculateLeadScore = (data: ContactFormData): number => {
+  export const calculateLeadScore = (data: ContactFormData): number => {
     let score = 50 // Base score
 
     // Service type scoring based on your actual services


### PR DESCRIPTION
## Summary
- export `ContactFormData` and `calculateLeadScore`
- add Jest tests for calculating lead scores

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68563f42be808326a0deece0716157ac